### PR TITLE
Rename module/repository to `tree-sitter-bazel`.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -17,15 +17,15 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 cc_library(
     name = "tree-sitter",
     implementation_deps = [
-        "@tree-sitter//lib/src:lib",
+        "@tree-sitter-bazel//lib/src:lib",
     ],
     target_compatible_with = select({
-        "@tree-sitter//build_config:implementation_deps_enabled": [],
+        "@tree-sitter-bazel//build_config:implementation_deps_enabled": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     visibility = ["//visibility:public"],
     deps = [
-        "@tree-sitter//lib/include/tree_sitter:api",
+        "@tree-sitter-bazel//lib/include/tree_sitter:api",
     ],
 )
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 _VERSION_TAG = "x.y.z"
 maybe(
   http_archive,
-  name = "tree-sitter",
+  name = "tree-sitter-bazel",
   urls = ["https://github.com/zadlg/tree-sitter-bazel/archive/refs/tags/v{version}.tar.gz".format(
       version = _VERSION_TAG,
   ),
@@ -50,8 +50,8 @@ Add the following to your `MODULE.bazel` file:
 
 ```starlark
 _VERSION_TAG = "x.y.z"
-bazel_dep(name = "tree-sitter", version = _VERSION_TAG)
-archive_override("tree-sitter",
+bazel_dep(name = "tree-sitter-bazel", version = _VERSION_TAG)
+archive_override("tree-sitter-bazel",
     urls = ["https://github.com/zadlg/tree-sitter-bazel/archive/refs/tags/v{version}.tar.gz".format(
         version = _VERSION_TAG,
     )],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,10 +15,10 @@
 "zadlg/tree-sitter-bazel"
 
 module(
-    name = "tree-sitter",
+    name = "tree-sitter-bazel",
     version = "0.22.5",
     compatibility_level = 1,
-    repo_name = "tree-sitter",
+    repo_name = "tree-sitter-bazel",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ See [INSTALL.md](INSTALL.md).
 
 The following targets are exposed by this repository:
 
-  - `@tree-sitter//:tree-sitter` (or simply `@tree-sitter`): the tree-sitter C API.
+  - `@tree-sitter-bazel//:tree-sitter`: the tree-sitter C API.
 
 ## Build configurations<a name="build-config"></a>
 
 The following build configuration are available:
 
-  - `@tree-sitter//build_config:wasm`: enable wasm (**not yet supported**).
-  - `@tree-sitter//build_config:hide_symbols`: hide symbols (default: _false_).
+  - `@tree-sitter-bazel//build_config:wasm`: enable wasm (**not yet supported**).
+  - `@tree-sitter-bazel//build_config:hide_symbols`: hide symbols (default: _false_).
 
 
 [`tree-sitter`]: https://github.com/tree-sitter/tree-sitter

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workspace(name = "tree-sitter")
+workspace(name = "tree-sitter-bazel")
 
 load(":repositories.bzl", "tree_sitter_repositories", "tree_sitter_sources")
 

--- a/build_config/BUILD
+++ b/build_config/BUILD
@@ -29,5 +29,5 @@ bool_flag(
 config_setting(
     name = "implementation_deps_enabled",
     values = {"experimental_cc_implementation_deps": "1"},
-    visibility = ["@tree-sitter//:__pkg__"],
+    visibility = ["@tree-sitter-bazel//:__pkg__"],
 )

--- a/build_config/hide_symbols/BUILD
+++ b/build_config/hide_symbols/BUILD
@@ -15,7 +15,7 @@
 config_setting(
     name = "enabled",
     flag_values = {
-        "@tree-sitter//build_config:hide_symbols": "true",
+        "@tree-sitter-bazel//build_config:hide_symbols": "true",
     },
-    visibility = ["@tree-sitter//:__subpackages__"],
+    visibility = ["@tree-sitter-bazel//:__subpackages__"],
 )

--- a/build_config/wasm/BUILD
+++ b/build_config/wasm/BUILD
@@ -15,7 +15,7 @@
 config_setting(
     name = "enabled",
     flag_values = {
-        "@tree-sitter//build_config:wasm": "true",
+        "@tree-sitter-bazel//build_config:wasm": "true",
     },
-    visibility = ["@tree-sitter//:__subpackages__"],
+    visibility = ["@tree-sitter-bazel//:__subpackages__"],
 )

--- a/lib/include/tree_sitter/BUILD
+++ b/lib/include/tree_sitter/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@tree-sitter//:rules.bzl", "use_defines_features", map = "in_pkg_srcs")
+load("@tree-sitter-bazel//:rules.bzl", "use_defines_features", map = "in_pkg_srcs")
 
 cc_library(
     name = "api",

--- a/lib/src/BUILD
+++ b/lib/src/BUILD
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@tree-sitter//:rules.bzl", "use_defines_features", map = "in_pkg_srcs")
+load("@tree-sitter-bazel//:rules.bzl", "use_defines_features", map = "in_pkg_srcs")
 
-_API = "@tree-sitter//lib/include/tree_sitter:api"
+_API = "@tree-sitter-bazel//lib/include/tree_sitter:api"
 
 cc_library(
     name = "alloc",
@@ -117,8 +117,8 @@ cc_library(
     name = "unicode",
     hdrs = map(["unicode.h"]),
     deps = [
-        "@tree-sitter//lib/src/unicode:utf16",
-        "@tree-sitter//lib/src/unicode:utf8",
+        "@tree-sitter-bazel//lib/src/unicode:utf16",
+        "@tree-sitter-bazel//lib/src/unicode:utf8",
     ],
 )
 
@@ -179,7 +179,7 @@ cc_library(
     name = "parser",
     srcs = map(["parser.c"]),
     hdrs = map(["parser.h"]),
-    visibility = ["@tree-sitter//:__pkg__"],
+    visibility = ["@tree-sitter-bazel//:__pkg__"],
     deps = [
         _API,
         ":alloc",
@@ -223,7 +223,7 @@ cc_library(
 
 cc_library(
     name = "lib",
-    visibility = ["@tree-sitter//:__pkg__"],
+    visibility = ["@tree-sitter-bazel//:__pkg__"],
     deps = [
         ":alloc",
         ":get_changed_ranges",

--- a/lib/src/unicode/BUILD
+++ b/lib/src/unicode/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@tree-sitter//:rules.bzl", map = "in_pkg_srcs")
+load("@tree-sitter-bazel//:rules.bzl", map = "in_pkg_srcs")
 
 cc_library(
     name = "utf",
@@ -42,7 +42,7 @@ cc_library(
     name = "utf8",
     hdrs = map(["utf8.h"]),
     strip_include_prefix = "/lib/src/",
-    visibility = ["@tree-sitter//lib/src:__pkg__"],
+    visibility = ["@tree-sitter-bazel//lib/src:__pkg__"],
     deps = [
         ":umachine",
         ":utf",
@@ -53,7 +53,7 @@ cc_library(
     name = "utf16",
     hdrs = map(["utf16.h"]),
     strip_include_prefix = "/lib/src/",
-    visibility = ["@tree-sitter//lib/src:__pkg__"],
+    visibility = ["@tree-sitter-bazel//lib/src:__pkg__"],
     deps = [
         ":ptypes",
         ":umachine",

--- a/rules.bzl
+++ b/rules.bzl
@@ -74,16 +74,16 @@ def in_pkg_srcs(filepaths, root = _DEFAULT_ROOT_LABEL):
 def use_defines_features():
     """Returns some values for `defines`, depending on enabled features.
 
-    See `@tree-sitter//features` sub-packages for supported features.
+    See `@tree-sitter-label//build_config` sub-packages for supported features.
     See [`cc_library::defines`](https://bazel.build/reference/be/c-cpp#cc_library.defines).
 
     Returns: list[str]
       List of defines depending on which features has been enabled.
     """
     return select({
-        "@tree-sitter//build_config/hide_symbols:enabled": ["TREE_SITTER_HIDE_SYMBOLS"],
+        "@tree-sitter-bazel//build_config/hide_symbols:enabled": ["TREE_SITTER_HIDE_SYMBOLS"],
         "//conditions:default": [],
     }) + select({
-        "@tree-sitter//build_config/wasm:enabled": ["TREE_SITTER_FEATURE_WASM"],
+        "@tree-sitter-bazel//build_config/wasm:enabled": ["TREE_SITTER_FEATURE_WASM"],
         "//conditions:default": [],
     })


### PR DESCRIPTION
Rename module/repository to `tree-sitter-bazel`.

See https://github.com/bazelbuild/bazel-central-registry/pull/1860#issuecomment-2072074292.
