### PR TITLE
fix: Update to latest release v0.26.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.26.8 (Mar 11 2026)
+
+## [`tree-sitter`] sync
+
+[`v0.26.8`](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.26.8)
+
 # v0.26.5 (Feb 3 2026)
 
 ## [`tree-sitter`] sync


### PR DESCRIPTION
Closes #54

Patch generated by `qwen3.6-35b-a3b via local API`.